### PR TITLE
Open new tab for clip.html in background

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -44,11 +44,11 @@ chrome.runtime.onMessage.addListener(async function listener(result) {
     
     // Open a new tab for clipping through the protocol, since we cannot go from the extension to this..
     if (result.testing) {
-        chrome.tabs.create({ url: redirectUrl , active: true},function(obsidianTab){
+        chrome.tabs.create({ url: redirectUrl , active: false},function(obsidianTab){
             // Since we're testing, we are not closing the tag...
         });
     } else {
-        chrome.tabs.create({ url: redirectUrl , active: true},function(obsidianTab){
+        chrome.tabs.create({ url: redirectUrl , active: false},function(obsidianTab){
             setTimeout(function() { chrome.tabs.remove(obsidianTab.id) }, 500);
         });
     }


### PR DESCRIPTION
Hi!  First off, let me say thank you for making such a nice extension.

I'm not sure it's originated from my setup (Ubuntu 22.04, Chrome v108), by executing the clipper extension it opens a temporary new tab (clip.html on GitHub Pages) and consequently changes the tab focus to the right-most tab.
This behavior is a bit annoying for me because I have to go back to the origin tab manually.

This PR makes the current active tab unchanged upon activating the extension, by opening a new tab in the background.